### PR TITLE
fix: complemented conditional

### DIFF
--- a/classes/queries.mjs
+++ b/classes/queries.mjs
@@ -25,9 +25,11 @@ class Queries extends Database {
       }
       const [ data ] = rows;
       const { id_usuario, estatus } = data;
-      if (!!estatus) {
+
+      if (!estatus && !id_usuario) {
         return { status: STATUSRESPONSE.NOTACTIVE, data: { estatus: 2 } }
       }
+      
       this.#query = this.getQuery('getRolesByUser');
       this.#params = [ id_usuario ];
       const { rows: roles } = await this.client.execute({


### PR DESCRIPTION
This pull request includes a change to the `Queries` class in the `classes/queries.mjs` file. The change modifies the condition to check both `estatus` and `id_usuario` before returning a response.

* [`classes/queries.mjs`](diffhunk://#diff-ef000689cabe072957946d9e94371662633f0b144872509e1781e5219dba08d4L28-R32): Updated the condition to check if both `estatus` is falsy and `id_usuario` is falsy before returning a not active status response.